### PR TITLE
修改seata undo的prepare query和prepare exec 为普通query和exec。

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -365,6 +365,8 @@ func (mc *mysqlConn) Exec(query string, args []driver.Value) (driver.Result, err
 }
 
 func (mc *mysqlConn) execAlways(query string, args []driver.Value) (driver.Result, error) {
+	return mc.Exec(query, args)
+
 	stmt, err := mc.Prepare(query)
 	if err != nil {
 		return nil, err
@@ -449,6 +451,8 @@ func (mc *mysqlConn) Query(query string, args []driver.Value) (driver.Rows, erro
 }
 
 func (mc *mysqlConn) prepareQuery(query string, args []driver.Value) (*binaryRows, error) {
+	return mc.query(query, args)
+
 	stmt, err := mc.Prepare(query)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description
seata undo在query和exec时都会打开prepare stmt，但未见到有stmt关闭的情况，从而可能导致mysql会话中内存增长。

